### PR TITLE
chore: Add self-approval rule

### DIFF
--- a/.github/self-approval.yml
+++ b/.github/self-approval.yml
@@ -1,0 +1,11 @@
+_extends: github-settings
+
+self_approval_comments:
+  - "I self-approve!"
+  - "I self-certify!"
+
+from_author:
+  - Cubik65536
+
+apply_labels:
+  - "can-be-merged/可以被合并"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Users can modify and redistribute the source code and use it for commercial prop
 
 ``` text
 RemoteMC-Core - Processing and API Core of RemoteMC Series
-Copyright (C) 2022 iXOR Techbology, Cubik65536, and contributors.
+Copyright (C) 2022 iXOR Technology, Cubik65536, and contributors.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
Add the [self-approval](https://github.com/CubikTech/self-approval) bot so senior maintainers can approve their own PR.